### PR TITLE
Dungeon NPC Scanner Changes

### DIFF
--- a/SVUI_NamePlates/Loader.lua
+++ b/SVUI_NamePlates/Loader.lua
@@ -133,112 +133,6 @@ SV.defaults[Schema] = {
     --},
 };
 
-MOD.public = {
-    ["dungeonCache"] = {
-        ["Grim Batol"] = {
-            ["InstanceID"] = 670,
-            ["NPC"] = {
-                ["Drahga Shadowburner"] = "40319",
-                ["Twilight Destroyer"] = "224609",
-                ["Forgemaster Throngus"] = "40177",
-                ["Mutated Hatchling"] = "224853",
-                ["Twilight Flamerender"] = "224240",
-                ["Twilight Enforcer"] = "224276",
-                ["Trogg Dweller"] = "39450",
-                ["Twilight Beguiler"] = "40167",
-                ["Twilight Drake"] = "39390",
-                ["Faceless Corruptor"] = "39392",
-                ["Twilight Brute"] = "224152",
-                ["Twilight Warlock"] = "224271",
-                ["General Umbriss"] = "39625",
-                ["Molten Giant"] = "40166",
-                ["Twilight Earthcaller"] = "224219",
-                ["Valiona"] = "40320",
-                ["Erudax"] = "40484",
-                ["Twilight Overseer"] = "224221",
-                ["Twilight Lavabender"] = "224249",
-            },
-        },
-        ["Siege of Boralus"] = {
-            ["InstanceID"] = 1822,
-            ["NPC"] = {
-                ["Kul Tiran Footman"] = "141495",
-                ["Kul Tiran Wavetender"] = "141284",
-                ["Sergeant Bainbridge"] = "128649",
-                ["Kul Tiran Marksman"] = "141285",
-                ["Ashvane Commander"] = "128969",
-                ["Ashvane Cannoneer"] = "138465",
-                ["Blacktar Bomber"] = "129372",
-                ["Irontide Curseblade"] = "135258",
-                ["Chopper Redhook"] = "144160",
-                ["Bilge Rat Cutthroat"] = "137511",
-                ["Ashvane Destroyer"] = "137517",
-                ["Ashvane Spotter"] = "138255",
-                ["Ashvane Deckhand"] = "138464",
-                ["Dread Captain Lockwood"] = "129208",
-                ["Bilge Rat Demolisher"] = "135245",
-                ["Hadal Darkfathom"] = "128651",
-                ["Demolishing Terror"] = "137614",
-                ["Irontide Powdershot"] = "137521",
-                ["Scrimshaw Gutter"] = "141566",
-                ["Ashvane Sniper"] = "141938",
-                ["Irontide Raider"] = "129369",
-                ["Gripping Terror"] = "137405",
-                ["Ashvane Invader"] = "137516",
-                ["Irontide Waveshaper"] = "129370",
-                ["Bilge Rat Buccaneer"] = "129366",
-                ["Kul Tiran Halberd"] = "141283",
-                ["Bilge Rat Tempest"] = "129367",
-                ["Kul Tiran Vanguard"] = "138019",
-                ["Unknown"] = "132481",
-                ["Bilge Rat Pillager"] = "135241",
-                ["Viq'Goth"] = "128652",
-            },
-        },
-        ["The Necrotic Wake"] = {
-            ["InstanceID"] = 2286,
-            ["NPC"] = {
-                ["Zolramus Bonecarver"] = "163619",
-                ["Rotspew"] = "163620",
-                ["Flesh Crafter"] = "165872",
-                ["Skeletal Monstrosity"] = "165197",
-                ["Blight Bag"] = "165138",
-                ["Stitchflesh's Creation"] = "164578",
-                ["Stitching Assistant"] = "173044",
-                ["Corpse Harvester"] = "166302",
-                ["Zolramus Gatekeeper"] = "165137",
-                ["Zolramus Bonemender"] = "165222",
-                ["Patchwerk Soldier"] = "162729",
-                ["Zolramus Sorcerer"] = "163128",
-                ["Amarth"] = "163157",
-                ["Zolramus Necromancer"] = "163618",
-                ["Goregrind"] = "163621",
-                ["Brittlebone Mage"] = "163126",
-                ["Blightbone"] = "162691",
-                ["Brittlebone Crossbowman"] = "166079",
-                ["Kyrian Stitchwerk"] = "172981",
-                ["Brittlebone Warrior"] = "163122",
-                ["Goregrind Bits"] = "163622",
-                ["Shuffling Corpse"] = "171500",
-                ["Rotspew Leftovers"] = "163623",
-                ["Separation Assistant"] = "167731",
-                ["Spare Parts"] = "166264",
-                ["Nar'zudah"] = "165824",
-                ["Loyal Creation"] = "165911",
-                ["Nalthor the Rimebinder"] = "162693",
-                ["Corpse Collector"] = "173016",
-                ["Surgeon Stitchflesh"] = "162689",
-                ["Stitched Vanguard"] = "163121",
-                ["Skeletal Marauder"] = "165919",
-            },
-        },
-    },
-    ["npcColorMapping"] = {},
-}
-
---["dungeonCache"] = {}, --We want a table only for npcs scan in dungeon
---["npcColors"] = {}, --We want a table to store the mapping between npc and color
-
 --[name] = color
 local colors = {
     ["HUNTER"] = CreateColor(0.454, 0.698, 0),
@@ -267,9 +161,6 @@ local colors = {
     --["MONK2"] = CreateColor(0.33, 0.54, 0.52),
     ["DEMONHUNTER2"] = CreateColor(0.64, 0.19, 0.79),
     ["EVOKER2"] = CreateColor(0.20, 0.58, 0.5),
-
-}
-local NPC = {
 
 }
 
@@ -383,15 +274,15 @@ local function UpdateFilterGroupOptions()
         }
     }
 end
-
 local function UpdateNPCOptions()
 
     if not SV.Options.args[Schema] then
         print ("|cFFFF0000 Trying to Update NPC but Nameplates is not loaded yet|r")
         return
     end
-    local dungeonCache = MOD.public.dungeonCache
-    local npcColorMapping = MOD.public.npcColorMapping
+
+    local dungeonCache = MOD.public.Dungeons.Cache
+    local npcColorMapping = MOD.public.Dungeons.NPCMapping
 
     SV.Options.args[Schema].args.commonGroup.args.NPCMapping = {
         type = "group",
@@ -421,70 +312,72 @@ local function UpdateNPCOptions()
         if not npcColorMapping[dungeon] then
             npcColorMapping[dungeon] = {}
         end
-        array[dungeon] = {
-            type = "group",
-            name = dungeon,
-            order = i,
-            get = function(k)
-                return npcColorMapping[dungeon][k[#k]]
-            end,
-            set = function(k, v)
-                npcColorMapping[dungeon][k[#k]] = v
-                MOD:UpdateAllPlates()
-            end,
-            args = {}
-        }
-
-        j = 1
-        for npcName, npcID in pairs(cache.NPC) do
-            if not npcColorMapping[dungeon][npcName] then
-                npcColorMapping[dungeon][npcName] = {}
-            end
-            array[dungeon].args[npcName] = {
-                name = npcName,
+        if type(cache) == "table" then
+            array[cache.Name] = {
                 type = "group",
-                order = order,
-                --guiInline  = true,
+                name = cache.Name,
+                order = i,
                 get = function(k)
-                    return npcColorMapping[dungeon][npcName][k[#k]]
+                    return npcColorMapping[dungeon][k[#k]]
                 end,
                 set = function(k, v)
-                    npcColorMapping[dungeon][npcName][k[#k]] = v
+                    npcColorMapping[dungeon][k[#k]] = v
                     MOD:UpdateAllPlates()
                 end,
-                args = {
-                    enable = {
-                        type = "toggle",
-                        order = 1,
-                        name = L["Enable"],
-                        desc = L["Override Nameplate color"]
-                    },
-                    id = {
-                        type = "description",
-                        name = L["NPC ID: "]..npcID,
-                        fontSize = "medium",
-                        width = "normal",
-                        order = 2,
-                    },
-                    color = {
-                        type = "select",
-                        name = L["Color"],
-                        order = 4,
-                        values = MOD:GetColoredSelector(true)
-                    },
-                    texture = {
-                        type = "select",
-                        dialogControl = "LSM30_Statusbar",
-                        order = 6,
-                        name = L["StatusBar Texture"],
-                        desc = L["Main statusbar texture."],
-                        values = AceVillainWidgets.statusbar
+                args = {}
+            }
+
+            j = 1
+            for npcID, npcName in pairs(cache.NPC) do
+                if not npcColorMapping[dungeon][npcID] then
+                    npcColorMapping[dungeon][npcID] = {}
+                end
+                array[cache.Name].args[npcName] = {
+                    name = npcName,
+                    type = "group",
+                    order = order,
+                    --guiInline  = true,
+                    get = function(k)
+                        return npcColorMapping[dungeon][npcID][k[#k]]
+                    end,
+                    set = function(k, v)
+                        npcColorMapping[dungeon][npcID][k[#k]] = v
+                        MOD:UpdateAllPlates()
+                    end,
+                    args = {
+                        enable = {
+                            type = "toggle",
+                            order = 1,
+                            name = L["Enable"],
+                            desc = L["Override Nameplate color"]
+                        },
+                        id = {
+                            type = "description",
+                            name = L["NPC ID: "]..npcID,
+                            fontSize = "medium",
+                            width = "normal",
+                            order = 2,
+                        },
+                        color = {
+                            type = "select",
+                            name = L["Color"],
+                            order = 4,
+                            values = MOD:GetColoredSelector(true)
+                        },
+                        texture = {
+                            type = "select",
+                            dialogControl = "LSM30_Statusbar",
+                            order = 6,
+                            name = L["StatusBar Texture"],
+                            desc = L["Main statusbar texture."],
+                            values = AceVillainWidgets.statusbar
+                        }
                     }
                 }
-            }
-            j = j + 1
+                j = j + 1
+            end
+            i = i + 1
         end
-        i = i + 1
     end
 
 end

--- a/SVUI_NamePlates/SVUI_NamePlates.lua
+++ b/SVUI_NamePlates/SVUI_NamePlates.lua
@@ -348,11 +348,13 @@ end
 local function GetNPCColor(unit)
 	if not IsInInstance() then return end
 
-	local npcColorMapping = MOD.public.npcColorMapping
-	local unitName = UnitName(unit)
-	local dungeonName = GetInstanceInfo()
+	local npcColorMapping = MOD.public.Dungeons.NPCMapping
 
-	local color = (npcColorMapping[dungeonName] and npcColorMapping[dungeonName][unitName] and npcColorMapping[dungeonName][unitName].enable and npcColorMapping[dungeonName][unitName].color) or nil
+	local guid = UnitGUID(unit)
+	local npcId = guid and select(6, strsplit("-", guid)) or nil
+	local instanceID = select(8, GetInstanceInfo())
+
+	local color = (npcColorMapping[instanceID] and npcColorMapping[instanceID][npcId] and npcColorMapping[instanceID][npcId].enable and npcColorMapping[instanceID][npcId].color) or nil
 	if color then
 		return MOD:GetColor(color)
 	else
@@ -365,11 +367,13 @@ local function GetNPCTexture(unit)
 		return config.StatusbarTexture
 	end
 
-	local npcColorMapping = MOD.public.npcColorMapping
-	local unitName = UnitName(unit)
-	local dungeonName = GetInstanceInfo()
+	local npcColorMapping = MOD.public.Dungeons.NPCMapping
 
-	local texture = (npcColorMapping[dungeonName] and npcColorMapping[dungeonName][unitName] and npcColorMapping[dungeonName][unitName].enable and npcColorMapping[dungeonName][unitName].texture) or nil
+	local guid = UnitGUID(unit)
+	local npcId = guid and select(6, strsplit("-", guid)) or nil
+	local instanceID = select(8, GetInstanceInfo())
+
+	local texture = (npcColorMapping[instanceID] and npcColorMapping[instanceID][npcId] and npcColorMapping[instanceID][npcId].enable and npcColorMapping[instanceID][npcId].texture) or nil
 	if texture then
 		return LSM:Fetch("statusbar", texture)
 	else
@@ -677,7 +681,8 @@ function MOD:InitialSetCVar()
 
 end
 
-function MOD:Load() 
+function MOD:Load()
+	self:LoadDungeonData()
 	self:UpdateLocals();
 	DriverFrame:SetScript('OnEvent', DriverFrame.OnEvent)
 	DriverFrame:RegisterEvent'PLAYER_ENTERING_WORLD'
@@ -1521,8 +1526,14 @@ function UnitFrameMixin:UpdateInVehicle()
 end
 
 function UnitFrameMixin:UpdateRaidTarget()
+	if not self.unit and not self.displayedUnit then
+		self.optionTable.healthBarColorOverride = nil
+		icon:Hide();
+		return
+	end
+
 	local icon = self.raidTargetIcon;
-	local index = GetRaidTargetIndex(self.unit)
+	local index = GetRaidTargetIndex(self.unit or self.displayedUnit)
 	if ( index ) then
 		SetRaidTargetIconTexture(icon, index);
 		icon:Show();

--- a/SVUI_NamePlates/components/scanner.lua
+++ b/SVUI_NamePlates/components/scanner.lua
@@ -50,6 +50,109 @@ CORE FUNCTIONS
 ##########################################################
 ]]--
 
+local function initDungeonCache()
+    return {
+        ["overrideName"] = true, --help to localized name in other locale than english by overriding unitName from existing ID
+        [670] = {
+            ["Name"] = "Grim Batol",
+            ["NPC"] = {
+                --["NPC_ID"] = UnitName -- in english
+                [40319] = "Drahga Shadowburner",
+                [224609]= "Twilight Destroyer",
+                [40177] = "Forgemaster Throngus",
+                [224853] = "Mutated Hatchling",
+                [224240] = "Twilight Flamerender",
+                [224276] = "Twilight Enforcer",
+                [39450] = "Trogg Dweller",
+                [40167] = "Twilight Beguiler",
+                [39390] = "Twilight Drake",
+                [39392] = "Faceless Corruptor",
+                [224152] = "Twilight Brute",
+                [224271] = "Twilight Warlock",
+                [39625] = "General Umbriss",
+                [40166] = "Molten Giant",
+                [224219] = "Twilight Earthcaller",
+                [40320] = "Valiona",
+                [40484] = "Erudax",
+                [224221] = "Twilight Overseer",
+                [224249] = "Twilight Lavabender",
+            }
+        },
+        [1822] = {
+            ["Name"] = "Siege of Boralus",
+            ["NPC"] = {
+                [141495] = "Kul Tiran Footman",
+                [141284] = "Kul Tiran Wavetender",
+                [128649] = "Sergeant Bainbridge",
+                [141285] = "Kul Tiran Marksman",
+                [128969] = "Ashvane Commander",
+                [138465] = "Ashvane Cannoneer",
+                [129372] = "Blacktar Bomber",
+                [135258] = "Irontide Curseblade",
+                [144160] = "Chopper Redhook",
+                [137511] = "Bilge Rat Cutthroat",
+                [137517] = "Ashvane Destroyer",
+                [138255] = "Ashvane Spotter",
+                [138464] = "Ashvane Deckhand",
+                [129208] = "Dread Captain Lockwood",
+                [135245] = "Bilge Rat Demolisher",
+                [128651] = "Hadal Darkfathom",
+                [137614] = "Demolishing Terror",
+                [137521] = "Irontide Powdershot",
+                [141566] = "Scrimshaw Gutter",
+                [141938] = "Ashvane Sniper",
+                [129369] = "Irontide Raider",
+                [137405] = "Gripping Terror",
+                [137516] = "Ashvane Invader",
+                [129370] = "Irontide Waveshaper",
+                [129366] = "Bilge Rat Buccaneer",
+                [141283] = "Kul Tiran Halberd",
+                [129367] = "Bilge Rat Tempest",
+                [138019] = "Kul Tiran Vanguard",
+                [132481] = "Unknown",
+                [135241] = "Bilge Rat Pillager",
+                [128652] = "Viq'Goth",
+            }
+        },
+        [2286] = {
+            ["Name"] = "The Necrotic Wake",
+            ["NPC"] = {
+                [163619] = "Zolramus Bonecarver",
+                [163620] = "Rotspew",
+                [165872] = "Flesh Crafter",
+                [165197] = "Skeletal Monstrosity",
+                [165138] = "Blight Bag",
+                [164578] = "Stitchflesh's Creation",
+                [173044] = "Stitching Assistant",
+                [166302] = "Corpse Harvester",
+                [165137] = "Zolramus Gatekeeper",
+                [165222] = "Zolramus Bonemender",
+                [162729] = "Patchwerk Soldier",
+                [163128] = "Zolramus Sorcerer",
+                [163157] = "Amarth",
+                [163618] = "Zolramus Necromancer",
+                [163621] = "Goregrind",
+                [163126] = "Brittlebone Mage",
+                [162691] = "Blightbone",
+                [166079] = "Brittlebone Crossbowman",
+                [172981] = "Kyrian Stitchwerk",
+                [163122] = "Brittlebone Warrior",
+                [163622] = "Goregrind Bits",
+                [171500] = "Shuffling Corpse",
+                [163623] = "Rotspew Leftovers",
+                [167731] = "Separation Assistant",
+                [166264] = "Spare Parts",
+                [165824] = "Nar'zudah",
+                [165911] = "Loyal Creation",
+                [162693] = "Nalthor the Rimebinder",
+                [173016] = "Corpse Collector",
+                [162689] = "Surgeon Stitchflesh",
+                [163121] = "Stitched Vanguard",
+                [165919] = "Skeletal Marauder",
+            }
+        },
+    }
+end
 --[[
 Scanner Functions
 ]]--
@@ -57,31 +160,19 @@ Scanner Functions
 function ScannerFrame:SetInstanceInCache()
     local name, instanceType, _, _, _, _, _, instanceID, _, _ = GetInstanceInfo()
 
-    if not dungeonCache[name] then
-        dungeonCache[name] = {
-            ["InstanceID"] = instanceID,
+    if not dungeonCache[instanceID] then
+        dungeonCache[instanceID] = {
+            ["Name"] = name,
             ["NPC"] = {
-                --["Name"] = NPC_ID
+                --["NPC_ID"] = UnitName -- in english
             }
         }
     end
-    self.dungeonName = name
+
+    self.instanceID = instanceID
 end
 
 function ScannerFrame:EnableCollect()
-
-    --local name, instanceType, _, _, _, _, _, instanceID, _, _ = GetInstanceInfo()
-    --
-    --if not dungeonCache[name] then
-    --    dungeonCache[name] = {
-    --        ["InstanceID"] = instanceID,
-    --        ["NPC"] = {
-    --            --["Name"] = NPC_ID
-    --        }
-    --    }
-    --end
-
-    --self.dungeonName = name
     self.enable = true
 end
 
@@ -95,26 +186,24 @@ end
 
 function ScannerFrame:NAME_PLATE_UNIT_ADDED(unit)
 
-    local npc = dungeonCache[self.dungeonName].NPC
-    local name = UnitName(unit)
+    local npc = dungeonCache[self.instanceID].NPC
+    local guid = UnitGUID(unit)
+    local npcId = guid and select(6, strsplit("-", guid)) or nil
 
-    if name and not npc[name] then
-        local guid = UnitGUID(unit)
-        local npcId = guid and select(6, strsplit("-", guid)) or nil
-        if not ignoreNPC[npcId] then
-            npc[name] = npcId
-            MOD:UpdateNPCOptions()
+    if npcId and not ignoreNPC[npcId]  then
+
+        if not npc[npcId] or dungeonCache.overrideName then
+            npc[npcId] = UnitName(unit)
         end
+        MOD:UpdateNPCOptions()
     end
+
 end
 
 function ScannerFrame:OnEvent(event, ...)
     if event == "PLAYER_ENTERING_WORLD" then
         if IsInInstance() then
             self:SetInstanceInCache()
-        --    self:EnableCollect()
-        --else
-        --    self:DisableCollect()
         end
     elseif self:IsCollecting() then
         self[event](self, ...)
@@ -133,10 +222,21 @@ end
 function MOD:EnableDungeonScanner()
     if not self.enable then return end
 
-    dungeonCache = MOD.public.dungeonCache
+    DevTool:AddData("EnableDungeonScanner", "EnableDungeonScanner")
+
+    dungeonCache = self.public.Dungeons.Cache
     --ScannerFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
     ScannerFrame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
     ScannerFrame:SetScript("OnEvent", ScannerFrame.OnEvent)
+end
+
+function MOD:LoadDungeonData()
+
+    if not self.public then self.public = {} end
+    if not self.public.Dungeons then self.public.Dungeons = {} end
+    if not self.public.Dungeons.Cache then self.public.Dungeons.Cache = initDungeonCache() end
+    if not self.public.Dungeons.NPCMapping then self.public.Dungeons.NPCMapping = {} end
+
 end
 
 function MOD:IsCollecting()
@@ -144,21 +244,17 @@ function MOD:IsCollecting()
 end
 
 function MOD:ActiveDungeonScanner(active)
-    --if not IsInInstance() then
-    --    self:DisableCollect()
-    --    self:DisableDungeonScanner()
-    --end
+
     if (active == self:IsCollecting()) then return end
 
     if active == true then
         ScannerFrame:EnableCollect()
+        self:EnableDungeonScanner()
 
         if IsInInstance() then
             --Activation while in a dungeon
             ScannerFrame:SetInstanceInCache()
         end
-
-        self:EnableDungeonScanner()
 
         print ("SV Dungeon NPC Scanner is now enabled")
     else


### PR DESCRIPTION
Change the approach of the NPC Scanner to use ID as primary key in the associative array instead of Name, since Name change with locales